### PR TITLE
Add description of auto-requesting certificates from ingresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ metadata:
   name: test-ingress
     annotations:
         cert-manager.io/issuer: "adcs-issuer" #use specific name of issuer
-            cert-manager.io/issuer-kind: "AdcsIssuer" #or AdcsClusterIssuer
-                cert-manager.io/issuer-group: "adcs.certmanager.csf.nokia.com"
+        cert-manager.io/issuer-kind: "AdcsIssuer" #or AdcsClusterIssuer
+        cert-manager.io/issuer-group: "adcs.certmanager.csf.nokia.com"
 ```
 in addition to
 ```

--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ status:
   state: ready
 ```
 
+#### Auto-request certificate from ingress
+Add the following to an `Ingress` for cert-manager to auto-generate a
+`Certificate` using `Ingress` information with ingress-shim
+```
+metadata:
+  name: test-ingress
+    annotations:
+        cert-manager.io/issuer: "adcs-issuer" #use specific name of issuer
+            cert-manager.io/issuer-kind: "AdcsIssuer" #or AdcsClusterIssuer
+                cert-manager.io/issuer-group: "adcs.certmanager.csf.nokia.com"
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ metadata:
             cert-manager.io/issuer-kind: "AdcsIssuer" #or AdcsClusterIssuer
                 cert-manager.io/issuer-group: "adcs.certmanager.csf.nokia.com"
 ```
+in addition to
+```
+spec:
+  tls:
+    - hosts:
+        - test-host.com
+            secretName: ingress-secret # secret cert-manager stores certificate in
+```
 
 ## Installation
 


### PR DESCRIPTION
Documentation of ingress annotations which allow auto-requesting certificates from ingresses using ingress-shim.

This is not documented (to the best of my knowledge) by cert-manager, but I have a pull request pending to make these ingress flags for out-of-tree issuers clearer in the cert-manager documentation.

Signed-off-by: Max Weis <maxrobweis@gmail.com>